### PR TITLE
Fixes cannot find config file due to symbolic/soft link.

### DIFF
--- a/smuggler.py
+++ b/smuggler.py
@@ -131,7 +131,7 @@ class Desyncr():
 			return
 			
 		if (self._configfile[1] != '/'):
-			self._configfile = os.path.dirname(os.path.abspath(__file__)) + "/configs/" + self._configfile
+			self._configfile = os.path.dirname(os.path.realpath(__file__)) + "/configs/" + self._configfile
 
 		try:
 			f = open(self._configfile)
@@ -224,7 +224,7 @@ class Desyncr():
 				_me = os.readlink(sys.argv[0])
 			else:
 				_me = sys.argv[0]
-			fname = os.path.abspath(os.path.dirname(_me)) + "/payloads/%s_%s_%s.txt" % (furl,ptype,name)
+			fname = os.path.realpath(os.path.dirname(_me)) + "/payloads/%s_%s_%s.txt" % (furl,ptype,name)
 			pretty_print("CRITICAL", "%s Payload: %s URL: %s\n" % \
 			(Fore.MAGENTA+ptype, Fore.CYAN+fname+Fore.MAGENTA, Fore.CYAN+self._url))
 			with open(fname, 'wb') as file:


### PR DESCRIPTION
Hi, I have a problem when my `smuggler.py` file is symlinked.
So, this is an improvement in my case that can't read the configuration file.

Fix by changing `abspath` to `realpath`, this will returns the canonical path of the specified filename, eliminating any symbolic links encountered in the path.

Regards.